### PR TITLE
[9.100.x-prod] use pkg-update module in devmode and builder images

### DIFF
--- a/prod-logic-swf-builder-rhel8-image.yaml
+++ b/prod-logic-swf-builder-rhel8-image.yaml
@@ -59,6 +59,7 @@ modules:
     - name: org.kie.kogito.swf.common.scripts
     - name: org.kie.kogito.swf.builder.runtime.osl
       version: "1.33.0"
+    - name: org.kie.kogito.pkg-update
 
 run:
   workdir: "/home/kogito/${PROJECT_ARTIFACT_ID}"

--- a/prod-logic-swf-devmode-rhel8-image.yaml
+++ b/prod-logic-swf-devmode-rhel8-image.yaml
@@ -56,6 +56,7 @@ modules:
     - name: org.kie.kogito.swf.devmode.runtime.common
     - name: org.kie.kogito.swf.devmode.runtime.osl
       version: "1.33.0"
+    - name: org.kie.kogito.pkg-update
 
 ports:
   - value: 8080


### PR DESCRIPTION
The pkg-update module is already used in data-index and jobs-services images and it helps in case UBI8 already released a new image version fixing a CVE on RHEL Layer but openjdk-17 image did not released yet.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>